### PR TITLE
traefik v2 update

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -34,8 +34,7 @@ services:
         restart: unless-stopped
         tty: true
         labels:
-            - traefik.backend=${DOCKER_APP_NAME}
-            - traefik.frontend.rule=Host:${DOCKER_APP_NAME}.com
+            - traefik.http.routers.webserver.rule=Host(`${DOCKER_APP_NAME}.com`)
             - traefik.docker.network=web
             - traefik.port=80
         volumes:


### PR DESCRIPTION
Hi Andy, thank you for this amazing work. Since Traefik v2 has [updated](https://doc.traefik.io/traefik/migration/v1-to-v2/) its router rules, frontend and backend rules are deprecated. I merged them under a "routers" rule and it works with latest versions of Traefik. 